### PR TITLE
Make Dockerfile more in line with jpetazzo/dind.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,16 @@ ENV DEBIAN_FRONTEND noninteractive
 
 
 # Adapted from: https://registry.hub.docker.com/u/jpetazzo/dind/dockerfile/
-RUN apt-get update -qq
-RUN apt-get install -qqy apt-transport-https
-
-# Install Docker from Docker Inc. repositories
-RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-RUN apt-get update -qq && \
-    apt-get install -y apparmor ca-certificates iptables lxc-docker && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Let's start with some basic stuff.
+RUN apt-get update -qq && apt-get install -qqy \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    lxc \
+    iptables
+    
+# Install Docker from Docker Inc. repositories.
+RUN curl -sSL https://get.docker.com/ubuntu/ | sh
 
 ADD wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker


### PR DESCRIPTION
Keeping this inline with the base dind Dockerfile to ease future updates.

Also, by using the script provided by docker for installing docker, it should automatically build correctly if docker changes the installation process.